### PR TITLE
Start derot library after a breaking change to idris-xml

### DIFF
--- a/ODF/ODF/ODS/CellRef.idr
+++ b/ODF/ODF/ODS/CellRef.idr
@@ -17,6 +17,6 @@ colName colIndex = pack $ colName' [] (S colIndex)
         rem => let c = chr $ 64 + cast rem in
                colName' (c :: acc) (n `div` 26)
 
-export
+export partial
 Show CellRef where
     show (MkCellRef row col) = colName col ++ show (S row)

--- a/ODF/ODF/ODS/Sheet.idr
+++ b/ODF/ODF/ODS/Sheet.idr
@@ -28,7 +28,13 @@ namespace Row
     namespace List
         export
         rows : Sheet -> List Row
-        rows (MkSheet sheet) = map MkRow $ filter (\elem => elem.name == rowName) $ evens sheet.content
+        rows (MkSheet sheet) = map MkRow
+                             $ mapMaybe (\case
+                                 Right elem => (if elem.name == rowName
+                                                then Just elem
+                                                else Nothing)
+                                 Left _ => Nothing)
+                                 $ Odd.evens sheet.content
 
     export
     emptyRow : Row
@@ -46,7 +52,13 @@ namespace Cell
     namespace List
         export
         cells : Row -> List Cell
-        cells (MkRow row) = map MkCell $ filter (\elem => elem.name == cellName) $ evens row.content
+        cells (MkRow row) = map MkCell
+                          $ mapMaybe (\case
+                              Right elem => if elem.name == cellName
+                                            then Just elem
+                                            else Nothing
+                              Left _ => Nothing)
+                          $ evens row.content
 
     export
     emptyCell : Cell

--- a/ODF/ODF/ODT/Template/Substitution.idr
+++ b/ODF/ODF/ODT/Template/Substitution.idr
@@ -12,7 +12,7 @@ infix 10 ::=
 public export
 data Substitutions : List String -> Type where
   Nil : Substitutions []
-  (::) : (subst : (String, Odd CharData Element)) -> Substitutions vars -> Substitutions (fst subst :: vars)
+  (::) : (subst : (String, Odd CharData (Either Misc Element))) -> Substitutions vars -> Substitutions (fst subst :: vars)
 
 %name Substitutions substs
 
@@ -26,7 +26,7 @@ done (UnsafeMkTemplate doc) = MkODT doc
 
 export
 substitute : (var : String)
-          -> (replacement : Odd CharData Element)
+          -> (replacement : Odd CharData (Either Misc Element))
           -> {auto 0 elem : Elem var vars}
           -> ODTTemplate vars
           -> ODTTemplate (dropElem vars elem)
@@ -34,11 +34,12 @@ substitute var replacement (UnsafeMkTemplate doc) = UnsafeMkTemplate $ mapConten
   where
     substituteContent : Element -> Element
     substituteContent = mapContent $ \content => Snd.do
-        elem@(EmptyElem (MkQName (Just $ MkName "template") (MkName name)) []) <- map substituteContent content
-            | elem => pure elem
+        elem@(EmptyElem (MkQName (Just $ MkName "template")
+                        (MkName name)) []) <- map ?substituteContent content
+        | elem => pure (Right elem)
         if name == var
             then replacement
-            else pure elem
+            else pure $ Right elem
 
 export
 render : ODTTemplate vars -> Substitutions vars -> ODT


### PR DESCRIPTION
I haven't quite worked out the fix to [ODF.ODT.Template.subsitute](https://github.com/madman-bob/idris2-odf/compare/main...ohad:idris2-odf:derot-after-breaking-change-to-xml#diff-d0de47afcaf23e4a09cc8c9bc1fb1a8949da0edd37fbc31d5487286c37cb5c04R38)